### PR TITLE
Fix the instructions in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Vencord Companion is a vscode extension to test Vencord patches & webpack finds 
 - Adds "Test Find" on any webpack finds that will test whether your filter finds exactly one module (and not more or none)
 - Adds "Test Patch" on any patches you define in definePlugin() that will test that your find is unique and your match and replace works and compiles correctly
 
-To use it you also need to compile Vencord with DEV (aka `pnpm build --watch` or `pnpm buildWeb --watch`) and enable the  "DevCompanion" plugin. Then just start Discord
+To use it you also need to compile Vencord with DEV (aka `pnpm build --watch --dev` or `pnpm buildWeb --watch --dev`) and enable the  "DevCompanion" plugin. Then just start Discord
 
 [Download on the vscode marketplace](https://marketplace.visualstudio.com/items?itemName=Vendicated.vencord-companion)
 


### PR DESCRIPTION
You need to add `--dev` to the build command for the DevCompanion extension to show up